### PR TITLE
(feat) Allow for specifying the IP path from terraform

### DIFF
--- a/plans/provision.pp
+++ b/plans/provision.pp
@@ -112,15 +112,15 @@ plan pecdm::provision(
         'target_mapping' => $provider ? {
           'google' => {
             'name' => 'metadata.internalDNS',
-            'uri'  => 'network_interface.0.access_config.0.nat_ip',
+            'uri'  => getvar('apply.ip_path.value', 'network_interface.0.access_config.0.nat_ip'),
           },
           'aws' => {
             'name' => 'private_dns',
-            'uri'  => 'public_ip',
+            'uri'  => getvar('apply.ip_path.value', 'public_ip'),
           },
           'azure' => {
             'name' => 'tags.internal_fqdn',
-            'uri'  => 'public_ip_address',
+            'uri'  => getvar('apply.ip_path.value', 'public_ip_address'),
           }
         }
       })

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -36,15 +36,15 @@ plan pecdm::upgrade(
         'target_mapping' => $provider ? {
           'google' => {
             'name' => 'metadata.internalDNS',
-            'uri'  => 'network_interface.0.access_config.0.nat_ip',
+            'uri'  => getvar('apply.ip_path.value', 'network_interface.0.access_config.0.nat_ip'),
           },
           'aws' => {
             'name' => 'private_dns',
-            'uri'  => 'public_ip',
+            'uri'  => getvar('apply.ip_path.value', 'public_ip'),
           },
           'azure' => {
             'name' => 'tags.internal_fqdn',
-            'uri'  => 'public_ip_address',
+            'uri'  => getvar('apply.ip_path.value', 'public_ip_address'),
           }
         }
       })


### PR DESCRIPTION
Prior to this PR, the URI in the terraform resolve_references was
hard coded. As different terraform configurations may have different
paths to the IP address, the code needs to be dynamic to handle the
differences. This commit allows for the terraform output to present an
`ip_path` output to specify the path to the IP address for the resource.
If it is not specified, the default will be used.

This can be used with an output like the following. 

```
output "ip_path" {
  value       = var.subnetwork_project == null ? "network_interface.0.access_config.0.nat_ip" : "network_interface.0.network_ip"
  description = "The path to the IP Address for the instance"
}
```