### PR TITLE
Ensure terraform has been initialized before destroying

### DIFF
--- a/plans/destroy.pp
+++ b/plans/destroy.pp
@@ -13,6 +13,10 @@ plan pecdm::destroy(
 
   $tf_dir = ".terraform/${provider}_pe_arch"
 
+  # Ensure the Terraform project directory has been initialized ahead of
+  # attempting a destroy
+  run_task('terraform::initialize', 'localhost', dir => $tf_dir)
+
   $vars_template = @(TFVARS)
     <% unless $project == undef { -%>
     project        = "<%= $project %>"


### PR DESCRIPTION
Prior to this PR, if a user tried to run destroy before doing a
provision, the plan would fail because terraform had not been
initialized. This PR adds the terraform initialize to the destroy
plan to allow the destroy plan to be functional even if there are no
deployed instances.