### PR TITLE
upgrades peadm to 3.3.0 to support PE 2021.4

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -10,7 +10,7 @@ mod 'WhatsARanjit-node_manager', '0.7.5'
 # Modules from Git
 mod 'puppetlabs-peadm',
     git: 'https://github.com/puppetlabs/puppetlabs-peadm.git',
-    ref: 'v3.0.1'
+    ref: 'v3.3.0'
 
 # External non-Puppet content
 #


### PR DESCRIPTION
# Changes

I'm upgrading the PEADM version to 3.3.0 since it's the release that supports PE 2021.4

https://github.com/puppetlabs/puppetlabs-peadm/releases/tag/v3.3.0