### PR TITLE
upgrades peadm to 3.4.0 to support PE 2021.5

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -10,7 +10,7 @@ mod 'WhatsARanjit-node_manager', '0.7.5'
 # Modules from Git
 mod 'puppetlabs-peadm',
     git: 'https://github.com/puppetlabs/puppetlabs-peadm.git',
-    ref: 'v3.3.0'
+    ref: 'v3.4.0'
 
 # External non-Puppet content
 #


### PR DESCRIPTION
### Changes

I'm upgrading the PEADM version to 3.4.0 since it's the release that supports PE 2021.5

**Related links**

https://github.com/puppetlabs/puppetlabs-peadm/releases/tag/v3.4.0

https://github.com/puppetlabs/puppetlabs-peadm/commit/7b21708d596dcb5f003203b2b445f55ffa9adf1e