### PR TITLE
Switch lb_ip_mode default to private

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Types of things you'll be paying your cloud provider for
 
 **Parameter requirements**
 
-Due to the creation of an elb load balancer (32 characters name limit) using the aws provider the project name can't be longer than 9 characters.
+* `lb_ip_mode`: Default is **private**, which will result in load balancer creation that is only accessible from within the VPC where PE is provisioned. To access the load balancer your agents will need to reside within the same VPC as PE or have its VPC peered so private IPs can be routed between PE and the agent's VPC. If you set this parameter to **public** on AWS then the ELB creation will associate a public IP, potentially accessible from the internet. On GCP, setting parameter to **public** will result in PE deployment failure due to GCP not providing DNS entires for internet facing load balancers.
 
 **Example: params.json**
 
@@ -132,4 +132,4 @@ The number of options required are reduced when destroying a stack
 
 ## Limitations
 
-Only supports what peadm supports and AWS does not currently have parity with the GCP provider, e.g. AWS ignores a few parameters
+Only supports what peadm supports and not all supporting Terraform modules have parity with each other.

--- a/plans/provision.pp
+++ b/plans/provision.pp
@@ -16,7 +16,7 @@ plan pecdm::provision(
   Optional[String[1]]                           $subnet_project       = undef,
   Optional[Boolean]                             $disable_lb           = undef,
   Enum['private', 'public']                     $ssh_ip_mode          = 'public',
-  Enum['private', 'public']                     $lb_ip_mode           = 'public',
+  Enum['private', 'public']                     $lb_ip_mode           = 'private',
   Array                                         $firewall_allow       = [],
   Array                                         $dns_alt_names        = [],
   Hash                                          $extra_peadm_params   = {},
@@ -30,12 +30,17 @@ plan pecdm::provision(
   String[1]                                     $cloud_region         = $provider ? { 'azure' => 'westus2', 'aws' => 'us-west-2', default => 'us-west1' }, # lint:ignore:140chars
 ) {
 
-  if $provider == 'google' and $subnet.is_a(Array) {
-    fail_plan('Google subnet must be provided as a String, an Array of subnets is only applicable for AWS based deployments')
+  if $provider == 'google' {
+    if $subnet.is_a(Array) {
+      fail_plan('Google subnet must be provided as a String, an Array of subnets is only applicable for AWS based deployments')
+    }
+    if $lb_ip_mode == 'public' {
+      fail_plan('Setting lb_ip_mode parameter to public with the GCP provider is not currently supported due to lack of GCP provided DNS')
+    }
   }
 
   if $provider == 'aws' and $subnet_project {
-    fail_plan('Setting the parameter subnet_project is only applicable for Google deployments using a subnet shared from another project')
+    fail_plan('Setting subnet_project parameter is only applicable for Google deployments using a subnet shared from another project')
   }
 
   if $provider == 'azure' and $subnet {


### PR DESCRIPTION
Having the parameter set to public causes failures on GCP because public
load balancers do not get DNS entires. Public could be possible with
custom DNS but solution is convoluted. Public load balancer remains an
option for AWS based deployments.