### PR TITLE
tag for public IP dns addressed changed

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -35,5 +35,5 @@ mod 'terraform-aws_pe_arch',
 
 mod 'terraform-azure_pe_arch',
     git:          'https://github.com/puppetlabs/terraform-azure-pe_arch.git',
-    ref:          'c230728d06bbf75c2e1732904c6d5d756e2dfca2',
+    ref:          '0905d4c9e85ac3f12466bb6eddcd0de55fd6d1d5',
     install_path: '.terraform'

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -47,19 +47,19 @@ groups:
         dir: .terraform/azure_pe_arch
         resource_type: azurerm_linux_virtual_machine.server
         target_mapping:
-          name: tags.internal_fqdn
+          name: tags.internalDNS
           uri: public_ip_address
       - _plugin: terraform
         dir: .terraform/azure_pe_arch
         resource_type: azurerm_linux_virtual_machine.compiler
         target_mapping:
-          name: tags.internal_fqdn
+          name: tags.internalDNS
           uri: public_ip_address
       - _plugin: terraform
         dir: .terraform/azure_pe_arch
         resource_type: azurerm_linux_virtual_machine.psql
         target_mapping:
-          name: tags.internal_fqdn
+          name: tags.internalDNS
           uri: public_ip_address
   - name: agent_nodes
     targets:
@@ -79,5 +79,5 @@ groups:
         dir: .terraform/azure_pe_arch
         resource_type: azurerm_linux_virtual_machine.node
         target_mapping:
-          name: tags.internal_fqdn
+          name: tags.internalDNS
           uri: public_ip_address


### PR DESCRIPTION
The azure plugin changed the tag name for consistency, this change updates the terraform inventory to use the new name