### PR TITLE
adds the ruby task & plugin helper modules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,6 +7,8 @@ mod 'puppetlabs-bolt_shim', '0.4.0'
 mod 'puppetlabs-terraform', '0.6.1'
 mod 'puppetlabs-inifile', '5.2.0'
 mod 'WhatsARanjit-node_manager', '0.7.5'
+mod 'puppetlabs-ruby_task_helper', '0.6.1'
+mod 'puppetlabs-ruby_plugin_helper', '0.2.0'
 
 # Modules from Git
 mod 'puppetlabs-peadm',


### PR DESCRIPTION
### Changes

I'm adding these two modules because I found issues after I wiped out my local environment for PECDM.

This is what I did before finding the need to add these two modules to the Puppetfile:

1. Pull the latest changes from the `main` branch
2. Remove the previously installed stuff:
     `rm -rf .modules/ .plan_cache.json .resource_types/ .task_cache.json .terraform/ bolt-debug.log`