### PR TITLE
Leverage tf state refresh on AWS

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,11 +1,10 @@
 forge 'https://forge.puppet.com'
 
 # Modules from the Puppet Forge
-mod 'puppetlabs-stdlib', '8.1.0'
+mod 'puppetlabs-stdlib', '8.5.0'
 mod 'puppetlabs-apply_helpers', '0.3.0'
 mod 'puppetlabs-bolt_shim', '0.4.0'
-mod 'puppetlabs-terraform', '0.6.1'
-mod 'puppetlabs-inifile', '5.2.0'
+mod 'puppetlabs-inifile', '5.4.0'
 mod 'WhatsARanjit-node_manager', '0.7.5'
 mod 'puppetlabs-ruby_task_helper', '0.6.1'
 mod 'puppetlabs-ruby_plugin_helper', '0.2.0'
@@ -14,6 +13,9 @@ mod 'puppetlabs-ruby_plugin_helper', '0.2.0'
 mod 'puppetlabs-peadm',
     git: 'https://github.com/puppetlabs/puppetlabs-peadm.git',
     ref: '67bfcfa1f255a28f19ca79fc4d4e696203bc32bb'
+mod 'puppetlabs-terraform',
+    git: 'https://github.com/puppetlabs/puppetlabs-terraform.git',
+    ref: '0fb771251821fdbe110ec8b8c1fcc892b1ff16c7'
 
 # External non-Puppet content
 #

--- a/plans/subplans/provision.pp
+++ b/plans/subplans/provision.pp
@@ -209,7 +209,11 @@ plan pecdm::subplans::provision(
     run_plan('terraform::apply',
       dir           => $tf_dir,
       return_output => true,
-      var_file      => $tfvars_file
+      var_file      => $tfvars_file,
+      refresh_state => $provider ? {
+        'aws'   => true,
+        default => false,
+      }
     )
   }
 
@@ -277,7 +281,7 @@ plan pecdm::subplans::provision(
             }
           },
           'aws' => {
-            'name' => 'private_dns',
+            'name' => 'tags.internalDNS',
             'uri'  => $ssh_ip_mode ? {
               'private' => 'private_ip',
               default   => 'public_ip',

--- a/templates/inventory_yaml.epp
+++ b/templates/inventory_yaml.epp
@@ -60,19 +60,19 @@ groups:
         dir: .terraform/aws_pe_arch
         resource_type: aws_instance.server
         target_mapping:
-          name: public_dns
+          name: tags.internalDNS
           uri: <%= $uri_param %>
       - _plugin: terraform
         dir: .terraform/aws_pe_arch
         resource_type: aws_instance.compiler
         target_mapping:
-          name: public_dns
+          name: tags.internalDNS
           uri: <%= $uri_param %>
       - _plugin: terraform
         dir: .terraform/aws_pe_arch
         resource_type: aws_instance.psql
         target_mapping:
-          name: public_dns
+          name: tags.internalDNS
           uri: <%= $uri_param %>
     <%- } -%>
     <%- if $provider == 'azure' { -%>


### PR DESCRIPTION
To support the internalDNS pattern on AWS we much rung a Terraform refresh to pickup tag changes after the initial apply. Also updates some dependencies.