### PR TITLE
AWS extra Oregon

### DIFF
--- a/plans/provision.pp
+++ b/plans/provision.pp
@@ -202,6 +202,9 @@ plan pecdm::provision(
     extra_terraform_vars   => $extra_terraform_vars
   })
 
+  # So the results can be seen in verbose mode if $stage is set
+  out::verbose("pecdm::provision provisioned:\n\n${provisioned.to_json_pretty}\n")
+
   unless $stage {
     run_plan('pecdm::subplans::deploy', {
       inventory              => $provisioned['pe_inventory'],

--- a/plans/subplans/provision.pp
+++ b/plans/subplans/provision.pp
@@ -211,7 +211,16 @@ plan pecdm::subplans::provision(
       return_output => true,
       var_file      => $tfvars_file,
       refresh_state => $provider ? {
-        'aws'   => true,
+        'aws'   => false,
+        default => false,
+      }
+    )
+    run_plan('terraform::apply',
+      dir           => $tf_dir,
+      return_output => true,
+      var_file      => $tfvars_file,
+      refresh_state => $provider ? {
+        'aws'   => false,
         default => false,
       }
     )

--- a/plans/subplans/provision.pp
+++ b/plans/subplans/provision.pp
@@ -210,20 +210,17 @@ plan pecdm::subplans::provision(
       dir           => $tf_dir,
       return_output => true,
       var_file      => $tfvars_file,
-      refresh_state => $provider ? {
-        'aws'   => false,
-        default => false,
-      }
+      refresh_state => false,
     )
-    run_plan('terraform::apply',
-      dir           => $tf_dir,
-      return_output => true,
-      var_file      => $tfvars_file,
-      refresh_state => $provider ? {
-        'aws'   => false,
-        default => false,
-      }
-    )
+    # run the apply a second time on aws
+    if $provider == 'aws' {
+      run_plan('terraform::apply',
+        dir           => $tf_dir,
+        return_output => true,
+        var_file      => $tfvars_file,
+        refresh_state => false,
+      )
+    }
   }
 
   # A pretty basic target config that just ensures we'll SSH into linux hosts


### PR DESCRIPTION
This fixes #99. spinning up a PE infra anywhere other than us-west-2 now works. 

All this does is run the `terraform::apply` task twice, with no refresh (whereas the code used to call `terraform::apply` once but with a refresh afterwards). It seems that the refresh was causing various elements of the tfstate file get nuked whereas the second apply makes one further change and gets the tfstate file where it needs to be for the resolving of references to complete successfully. 

I have no idea exactly where the default region from variables.tf is being picked up in favour of the cloud_region parameter, but this PR avoids it somehow. 