### PR TITLE
Add plan spec tests (based on pr #109)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,4 +3,8 @@
 ---
 fixtures:
   forge_modules:
-#     stdlib: "puppetlabs/stdlib"
+    stdlib: "puppetlabs/stdlib"
+    peadm: "puppetlabs/peadm"
+    terraform: "puppetlabs/terraform"
+    ruby_task_helper: "puppetlabs/ruby_task_helper"
+    ruby_plugin_helper: "puppetlabs/ruby_plugin_helper"

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 .project
 .envrc
 /spec/fixtures/litmus_inventory.yaml
+.modules
+.resource_types

--- a/.sync.yml
+++ b/.sync.yml
@@ -2,3 +2,8 @@
 .gitignore:
   required:
     - '---/inventory.yaml'
+Gemfile:
+  required:
+    ':development':
+      - gem: 'bolt'
+        version: '>= 3.10.0'

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development do
   gem "rubocop-performance", '= 1.16.0',         require: false
   gem "rubocop-rspec", '= 2.19.0',               require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "bolt", '>= 3.10.0',                       require: false
 end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-pecdm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Cody Herriges",
   "summary": "Automatic Puppet Enterprise, a Bolt driven fusion of peadm and teraform",
   "license": "Apache-2.0",

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -51,7 +51,6 @@ plan pecdm::upgrade(
       },
     },
   }
-  out::message('3')
 
   $target_config = $native_ssh ? {
     true  => deep_merge($_target_config, $native_ssh_config),
@@ -101,7 +100,6 @@ plan pecdm::upgrade(
   $inventory.each |$k, $v| { $v.each |$target| {
       Target.new($target.merge($target_config)).add_to_group('peadm_nodes')
   } }
-  out::message('6')
 
   $peadm_configs = run_task('peadm::get_peadm_config', [
       get_targets([

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -8,7 +8,10 @@ plan pecdm::upgrade(
   Hash                                     $extra_peadm_params = {},
   String[1]                                $ssh_user           = $provider ? { 'aws' => 'ec2-user', default => undef },
 ) {
+  log::trace('.')
   Target.new('name' => 'localhost', 'config' => { 'transport' => 'local' })
+
+  log::trace('0')
 
   if $provider {
     $_provider = $provider
@@ -30,6 +33,7 @@ plan pecdm::upgrade(
     $tf_dir = ".terraform/${_provider}_pe_arch"
   }
 
+  out::message('1')
   # A pretty basic target config that just ensures we'll SSH into linux hosts
   # with a specific user and properly escalate to the root user
   $_target_config = {
@@ -42,6 +46,7 @@ plan pecdm::upgrade(
       },
     },
   }
+  out::message('2')
 
   $native_ssh_config = {
     'config' => {
@@ -51,11 +56,13 @@ plan pecdm::upgrade(
       },
     },
   }
+  out::message('3')
 
   $target_config = $native_ssh ? {
     true  => deep_merge($_target_config, $native_ssh_config),
     false => $_target_config
   }
+  out::message('4')
 
   # Generate an inventory of freshly provisioned nodes using the parameters that
   # are appropriate based on which cloud provider we've chosen to use. Utilizes
@@ -96,10 +103,12 @@ plan pecdm::upgrade(
       })
     }
   }
+  out::message('5')
 
   $inventory.each |$k, $v| { $v.each |$target| {
       Target.new($target.merge($target_config)).add_to_group('peadm_nodes')
   } }
+  out::message('6')
 
   $peadm_configs = run_task('peadm::get_peadm_config', [
       get_targets([
@@ -107,12 +116,14 @@ plan pecdm::upgrade(
           getvar('inventory.server.1.name'),
       ].peadm::flatten_compact)
   ])
+  out::message('7')
 
   if ($peadm_configs.count == 1) or ($peadm_configs[0].value == $peadm_configs[1].value) {
     $current_config = $peadm_configs[0].value
   } else {
     fail_plan('Collected PEADM configs do not match, primary and replica must report equal configurations to upgrade')
   }
+  out::message('8')
 
   $params = {
     'primary_host'            => getvar('current_config.params.primary_host'),
@@ -123,6 +134,7 @@ plan pecdm::upgrade(
     'compiler_pool_address'   => getvar('current_config.params.compiler_pool_address'),
     'version'                 => $version,
   }
+  log::trace('9')
 
   $peadm_upgrade_params = $params + $extra_peadm_params
 
@@ -130,4 +142,5 @@ plan pecdm::upgrade(
 
   # Once all the infrastructure data has been collected, peadm takes over
   run_plan('peadm::upgrade', $peadm_upgrade_params)
+  log::trace('10')
 }

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -8,10 +8,7 @@ plan pecdm::upgrade(
   Hash                                     $extra_peadm_params = {},
   String[1]                                $ssh_user           = $provider ? { 'aws' => 'ec2-user', default => undef },
 ) {
-  log::trace('.')
   Target.new('name' => 'localhost', 'config' => { 'transport' => 'local' })
-
-  log::trace('0')
 
   if $provider {
     $_provider = $provider
@@ -33,7 +30,6 @@ plan pecdm::upgrade(
     $tf_dir = ".terraform/${_provider}_pe_arch"
   }
 
-  out::message('1')
   # A pretty basic target config that just ensures we'll SSH into linux hosts
   # with a specific user and properly escalate to the root user
   $_target_config = {
@@ -46,7 +42,6 @@ plan pecdm::upgrade(
       },
     },
   }
-  out::message('2')
 
   $native_ssh_config = {
     'config' => {
@@ -62,7 +57,6 @@ plan pecdm::upgrade(
     true  => deep_merge($_target_config, $native_ssh_config),
     false => $_target_config
   }
-  out::message('4')
 
   # Generate an inventory of freshly provisioned nodes using the parameters that
   # are appropriate based on which cloud provider we've chosen to use. Utilizes
@@ -103,7 +97,6 @@ plan pecdm::upgrade(
       })
     }
   }
-  out::message('5')
 
   $inventory.each |$k, $v| { $v.each |$target| {
       Target.new($target.merge($target_config)).add_to_group('peadm_nodes')
@@ -116,14 +109,12 @@ plan pecdm::upgrade(
           getvar('inventory.server.1.name'),
       ].peadm::flatten_compact)
   ])
-  out::message('7')
 
   if ($peadm_configs.count == 1) or ($peadm_configs[0].value == $peadm_configs[1].value) {
     $current_config = $peadm_configs[0].value
   } else {
     fail_plan('Collected PEADM configs do not match, primary and replica must report equal configurations to upgrade')
   }
-  out::message('8')
 
   $params = {
     'primary_host'            => getvar('current_config.params.primary_host'),
@@ -134,7 +125,6 @@ plan pecdm::upgrade(
     'compiler_pool_address'   => getvar('current_config.params.compiler_pool_address'),
     'version'                 => $version,
   }
-  log::trace('9')
 
   $peadm_upgrade_params = $params + $extra_peadm_params
 
@@ -142,5 +132,4 @@ plan pecdm::upgrade(
 
   # Once all the infrastructure data has been collected, peadm takes over
   run_plan('peadm::upgrade', $peadm_upgrade_params)
-  log::trace('10')
 }

--- a/spec/plans/destroy_spec.rb
+++ b/spec/plans/destroy_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'pecdm::destroy' do
+  include BoltSpec::Plans
+
+  params = {
+    'provider' => 'aws',
+  }
+
+  it 'destroy plan succeeds' do
+    expect_plan('pecdm::subplans::destroy').be_called_times(1)
+    expect(run_plan('pecdm::destroy', params)).to be_ok
+  end
+end

--- a/spec/plans/provision_spec.rb
+++ b/spec/plans/provision_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'pecdm::provision' do
+  include BoltSpec::Plans
+
+  params = {
+    'provider' => 'aws',
+    'console_password' => 'puppetlabs',
+  }
+
+  it 'provision plan succeeds' do
+    allow_any_out_message
+    allow_any_out_verbose
+    expect_plan('pecdm::subplans::provision').be_called_times(1)
+    expect_plan('pecdm::subplans::deploy').be_called_times(1)
+    expect(run_plan('pecdm::provision', params)).to be_ok
+  end
+end

--- a/spec/plans/upgrade_spec.rb
+++ b/spec/plans/upgrade_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'bolt/target'
+require 'bolt/inventory'
+require 'bolt/plugin'
+
+describe 'pecdm::upgrade' do
+  include BoltSpec::Plans
+
+  params = {
+    'provider' => 'aws',
+  }
+
+  let(:target_data) { { 'name' => 'my-target', 'uri' => 'ssh://my-target' } }
+  # let(:inventory) { instance_double(Bolt::Inventory::Inventory).as_null_object }
+  let(:inventory) { instance_double(Bolt::Inventory::Inventory) }
+  let(:target) { Bolt::Target.new('my-target', inventory) }
+  let(:plugin) { instance_double('Plugin') }
+
+  before :each do
+    allow(plugin).to receive(:resolve_references).and_return([target_data])
+    allow(inventory).to receive(:get_targets).and_return([target])
+    allow(inventory).to receive(:targets).and_return([target])
+    allow(inventory).to receive(:target_implementation_class).with(no_args).and_return(Bolt::Target)
+    allow(inventory).to receive(:version).and_return(2)
+    allow(inventory).to receive(:create_target_from_hash).and_return(target)
+    allow(inventory).to receive(:plugins).and_return(plugin)
+    allow(inventory).to receive(:add_to_group)
+    # allow_any_instance_of(Bolt::PAL::YamlPlan::Evaluator).to receive(:resolve_references).and_return([target])
+    Bolt::Logger.configure({ 'console' => { 'level' => 'trace' } }, true)
+  end
+
+  it 'upgrade plan succeeds' do
+    puts "Inventory: #{inventory.inspect}"
+    allow_any_out_message
+    allow_task('peadm::get_peadm_config').be_called_times(1)
+    allow_plan('peadm::upgrade').be_called_times(1)
+    expect(run_plan('pecdm::upgrade', params)).to be_ok
+  end
+end

--- a/spec/plans/upgrade_spec.rb
+++ b/spec/plans/upgrade_spec.rb
@@ -3,8 +3,13 @@ require 'bolt/target'
 require 'bolt/inventory'
 require 'bolt/plugin'
 
-describe 'pecdm::upgrade' do
-  include BoltSpec::Plans
+#FIXME this test is failing because of the inventory requirement
+# 1) pecdm::upgrade upgrade plan succeeds
+# Failure/Error: expect(run_plan('pecdm::upgrade', params)).to be_ok
+#   expected `#<Bolt::PlanResult:0x000000010f27dc50 @value=#<Bolt::PAL::PALError: no implicit conversion of String into Integer>, @status="failure">.ok?` to be truthy, got false
+# # ./spec/plans/upgrade_spec.rb:37:in `block (2 levels) in <top (required)>'describe 'pecdm::upgrade' do
+
+include BoltSpec::Plans
 
   params = {
     'provider' => 'aws',

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Load the BoltSpec library
+require 'bolt_spec/plans'
+
+# Configure Puppet and Bolt for testing
+BoltSpec::Plans.init
+
+# This environment variable can be read by Ruby Bolt tasks to prevent unwanted
+# auto-execution, enabling easy unit testing.
+ENV['RSPEC_UNIT_TEST_MODE'] ||= 'TRUE'


### PR DESCRIPTION
Since there are now so many dependencies and pdk configuration is complex, I propose to start adding some spec tests to keep confidence.

This PR is the first attempt to make everything testable by `pdk test unit`. The next step would be to add automatic testing in Github Actions.

Of the three spec tests, I didn't succeed in getting `upgrade_spec` to pass due to complexity of mocking needed and also difficulty getting sensible logging from Bolt. So that test is WIP but I still think adding the other two passing tests is a good  thing since it checks the dependencies.