### PR TITLE
Update Puppetfile to latest modules to resolve stdlib issue

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,18 +1,17 @@
 forge 'https://forge.puppet.com'
 
-# Modules from the Puppet Forge
-mod 'puppetlabs-stdlib', '8.5.0'
+mod 'puppetlabs-stdlib', '9.2.0'
 mod 'puppetlabs-apply_helpers', '0.3.0'
 mod 'puppetlabs-bolt_shim', '0.4.0'
-mod 'puppetlabs-inifile', '5.4.0'
-mod 'WhatsARanjit-node_manager', '0.7.5'
+mod 'puppetlabs-inifile', '6.1.0'
+mod 'WhatsARanjit-node_manager', '0.8.0'
 mod 'puppetlabs-ruby_task_helper', '0.6.1'
 mod 'puppetlabs-ruby_plugin_helper', '0.2.0'
 
 # Modules from Git
 mod 'puppetlabs-peadm',
     git: 'https://github.com/puppetlabs/puppetlabs-peadm.git',
-    ref: '67bfcfa1f255a28f19ca79fc4d4e696203bc32bb'
+    ref: '97ec11b4ef0e25c55b6ebb677e1eb06f70766b66'
 mod 'puppetlabs-terraform',
     git: 'https://github.com/puppetlabs/puppetlabs-terraform.git',
     ref: 'df32b4993b8e6e30fa57feb0e689b03fd0e1dc9d'


### PR DESCRIPTION
Currently PECDM module errors after some recent PRs I think this is due to module updates.

```
Finished: plan pecdm::provision in 2 min, 51 sec
Evaluation Error: Unknown function: 'stdlib::merge'. (file: C:/Users/David Sandilands/PECDM environments/pecdmlatest/plans/subplans/provision.pp, line: 308, column: 41)
  (file: C:/Users/David Sandilands/PECDM environments/pecdmlatest/plans/subplans/provision.pp, line: 308, column: 41)
```

This PR updates all the Puppetfile modules to latest

and removes the warning message on bolt module install as a result too

`Metadata for task 'node_manager::update_classes' contains unknown keys: summary. This could be a typo in the task metadata or might result in incorrect behavior. [ID: unknown_task_metadata_keys]`